### PR TITLE
Add calibrated presets for mc_data_vwc_parameters

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -173,7 +173,9 @@
 #' Data frame hosting the coefficients for the conversion of TMS raw moisture units to
 #' volumetric warer content. The coefficients come from laboratory calibration for several
 #' soil types. For the best performance you should specify the soil type in case you know it
-#' and in case it could be approximated to the available calibration e.g sand, loam, loamy sand....
+#' and in case it could be approximated to the available calibration. The available calibrated
+#' presets are: "sand", "loamy sand A", "loamy sand B", "sandy loam A", "sandy loam B", "loam",
+#' "silt loam", "peat", "water", "universal", "sand TMS1", "loamy sand TMS1" and "silt loam TMS1"
 #' See [myClim::mc_calc_vwc()]
 #'
 #' data.frame with columns:


### PR DESCRIPTION
I had no clue of which soil types of mc_data_vwc_parameter I could use for the mc_calc_vwc() function, so I had to dive into the code until I found them here: https://github.com/ibot-geoecology/myClim/blob/a06730359da80cd962f3709097f619236fcd5d29/data-raw/mc_data_vwc_parameters.R

Here I add the available calibration presets to the documentation.

Let me know if I did it correctly and feel free to modify and correct it according to your criteria.